### PR TITLE
fix: use robust method for focusing on open instead of relying on browser for focus functionality

### DIFF
--- a/src/auro-drawer-content.js
+++ b/src/auro-drawer-content.js
@@ -70,7 +70,8 @@ export class AuroDrawerContent extends LitElement {
 
   handleWrapperTransitionEnd() {
     if (!this.visible) return;
-    this.shadowRoot.querySelector('.wrapper').focus();
+    if (!this.focusTrap) return;
+    this.focusTrap.focusFirstElement();
   }
 
   updated(changedProperties) {
@@ -104,7 +105,7 @@ export class AuroDrawerContent extends LitElement {
 
   render() {
     return html`
-    <div class="wrapper" @transitionend=${this.handleWrapperTransitionEnd}>
+    <div class="wrapper" tabindex="-1" @transitionend=${this.handleWrapperTransitionEnd}>
       ${this.unformatted ? '' : html`
         <div class="header" part="drawer-header">
             <h1 class="heading heading--700 util_stackMarginNone--top" id="drawer-header">

--- a/src/util/FocusTrap.js
+++ b/src/util/FocusTrap.js
@@ -71,9 +71,9 @@ export class FocusTrap {
   // If the container somehow gets focus, move the focus back into the container, accounting for the tab direction
   _onContainerFocus = () => {
     if (this.tabDirection === 'backward') {
-      this._focusLastElement();
+      this.focusLastElement();
     } else {
-      this._focusFirstElement();
+      this.focusFirstElement();
     }
   };
 
@@ -85,13 +85,13 @@ export class FocusTrap {
 
   _onBookendFocusStart = () => {
     if (this.tabDirection === 'backward') {
-      this._focusLastElement();
+      this.focusLastElement();
     }
   };
 
   _onBookendFocusEnd = () => {
     if (this.tabDirection === 'forward') {
-      this._focusFirstElement();
+      this.focusFirstElement();
     }
   };
 
@@ -108,12 +108,12 @@ export class FocusTrap {
     return results;
   }
 
-  _focusFirstElement() {
+  focusFirstElement() {
     const focusables = this._getFocusableElements();
     if (focusables.length) focusables[0].focus();
   }
 
-  _focusLastElement() {
+  focusLastElement() {
     const focusables = this._getFocusableElements();
     if (focusables.length) focusables[focusables.length - 1].focus();
   }


### PR DESCRIPTION
fix: use robust method for focusing on open instead of relying on browser for focus functionality

- Expose focusFirstElement and focusLastElement methods in the FocusTrap Service
- Consume focusFirstElement via this.focusTrap in auro-drawer-content to focus first element on open

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve focus management by exposing explicit focus control methods in the FocusTrap service and using them to reliably focus the first element when AuroDrawerContent opens.

Bug Fixes:
- Programmatically focus the first focusable element on drawer open instead of relying on browser default behavior.

Enhancements:
- Expose focusFirstElement and focusLastElement methods on the FocusTrap service.
- Add tabindex="-1" to the drawer wrapper to enable proper focus trapping.