### PR TITLE
fix: update focus trap logic to improve focus management

### DIFF
--- a/src/drawerVersion.js
+++ b/src/drawerVersion.js
@@ -1,1 +1,1 @@
-export default '4.1.2'
+export default '4.1.4'

--- a/src/util/FocusTrap.js
+++ b/src/util/FocusTrap.js
@@ -1,4 +1,18 @@
+// Do not add auro elements to this unless absolutely necessary
 const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  '[role="tab"]:not([disabled])',
+  '[role="link"]:not([disabled])',
+  '[role="button"]:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+  '[contenteditable]:not([contenteditable="false"])'
+];
+
+const FOCUSABLE_COMPONENTS = [
   'auro-checkbox',
   'auro-radio',
   'auro-dropdown',
@@ -10,13 +24,8 @@ const FOCUSABLE_SELECTORS = [
   'auro-select',
   'auro-datepicker',
   'auro-hyperlink',
-  'a[href]', 
-  'button:not([disabled])', 
-  'textarea:not([disabled])', 
-  'input:not([disabled])', 
-  'select:not([disabled])', 
-  '[tabindex]:not([tabindex="-1"])'
-];
+  'auro-accordion',
+]
 
 export class FocusTrap {
   constructor(container) {
@@ -26,86 +35,129 @@ export class FocusTrap {
 
     this.container = container;
     this.tabDirection = 'forward'; // or 'backward'
-    this.bookendStart = this._createBookend('start');
-    this.bookendEnd = this._createBookend('end');
 
     this._init();
-  }
-
-  _createBookend(position) {
-    const bookend = document.createElement('div');
-    bookend.tabIndex = 0;
-    bookend.className = `focus-bookend focus-bookend-${position}`;
-    return bookend;
   }
 
   _init() {
     // Support for shadow DOM / web components
     const appendEl = this.container.shadowRoot || this.container;
 
-    // Make the container explicitly unfocusable
-    // This is critical for shadow DOM hosts
-    this.container.tabIndex = -1;
-    
     // Add inert attribute to prevent focusing programmatically as well (if supported)
     if ('inert' in HTMLElement.prototype) {
       this.container.inert = false; // Ensure the container isn't inert
       this.container.setAttribute('data-focus-trap-container', true); // Mark for identification
     }
 
-    // Append bookends
-    appendEl.prepend(this.bookendStart);
-    appendEl.append(this.bookendEnd);
-
     // Track tab direction
     this.container.addEventListener('keydown', this._onKeydown);
-
-    // Focus looping
-    this.bookendStart.addEventListener('focus', this._onBookendFocusStart);
-    this.bookendEnd.addEventListener('focus', this._onBookendFocusEnd);
-    
-    // Add event listener to handle the edge case where container gets focus anyway
-    this.container.addEventListener('focus', this._onContainerFocus);
   }
 
-  // If the container somehow gets focus, move the focus back into the container, accounting for the tab direction
-  _onContainerFocus = () => {
-    if (this.tabDirection === 'backward') {
-      this.focusLastElement();
-    } else {
-      this.focusFirstElement();
-    }
-  };
-
   _onKeydown = (e) => {
+    
     if (e.key === 'Tab') {
+
+      // Set the tab direction based on the key pressed
       this.tabDirection = e.shiftKey ? 'backward' : 'forward';
-    }
-  };
 
-  _onBookendFocusStart = () => {
-    if (this.tabDirection === 'backward') {
-      this.focusLastElement();
-    }
-  };
+      // Get the active element(s) in the document and shadow root
+      // This will include the active element in the shadow DOM if it exists
+      // Active element may be inside the shadow DOM depending on delegatesFocus, so we need to check both
+      const actives =  [
+        document.activeElement,
+        ...document.activeElement.shadowRoot && [document.activeElement.shadowRoot.activeElement]
+      ]
 
-  _onBookendFocusEnd = () => {
-    if (this.tabDirection === 'forward') {
-      this.focusFirstElement();
+      // Update the focusable elements
+      const focusables = this._getFocusableElements();
+
+      // If we're at either end of the focusable elements, wrap around to the other end
+      const focusIndex =
+        actives.includes(focusables[0]) && this.tabDirection === 'backward'
+          ? focusables.length - 1
+          : actives.includes(focusables[focusables.length - 1]) && this.tabDirection === 'forward'
+            ? 0
+            : null;
+
+      if (focusIndex !== null) {
+        focusables[focusIndex].focus();
+        e.preventDefault(); // Prevent default tab behavior
+        e.stopPropagation(); // Stop the event from bubbling up
+      }
     }
   };
 
   _getFocusableElements() {
+    // Get elements in DOM order by walking the tree
+    const orderedFocusableElements = [];
 
-    // Get all focusable elements within the container based on the FOCUSABLE_SELECTORS constant
-    let results = Array.from(this.container.querySelectorAll(FOCUSABLE_SELECTORS.join(',')));
+    // Define a recursive function to collect focusable elements in DOM order
+    const collectFocusableElements = (root) => {
 
-    // Filter any unwanted elements
-    results = results
-      .filter( el => el.classList.contains('focus-bookend') === false) // Exclude bookends
+      // Check if current element is focusable
+      if (root.nodeType === Node.ELEMENT_NODE) {
+        // Check if this is one of our special Auro components
+        const isAuroComponent = FOCUSABLE_COMPONENTS.some(
+          component => root.tagName.toLowerCase()?.match(component)
+        );
 
-    // Return results
-    return results;
+        if (isAuroComponent) {
+          // Add the component itself as a focusable element and don't traverse its shadow DOM
+          orderedFocusableElements.push(root);
+          return; // Skip traversing inside this component
+        }
+
+        // Check if the element itself matches any selector
+        for (const selector of FOCUSABLE_SELECTORS) {
+          if (root.matches?.(selector) && !root.classList.contains('focus-bookend')) {
+            orderedFocusableElements.push(root);
+            break; // Once we know it's focusable, no need to check other selectors
+          }
+        }
+
+        // Process shadow DOM only for non-Auro components
+        if (root.shadowRoot) {
+          // Process shadow DOM children in order
+          if (root.shadowRoot.children) {
+            Array.from(root.shadowRoot.children).forEach(child => {
+              collectFocusableElements(child);
+            });
+          }
+        }
+
+        // Process slots and their assigned nodes in order
+        if (root.tagName === 'SLOT') {
+          const assignedNodes = root.assignedNodes({ flatten: true });
+          for (const node of assignedNodes) {
+            collectFocusableElements(node);
+          }
+        } else {
+          // Process light DOM children in order
+          if (root.children) {
+            Array.from(root.children).forEach(child => {
+              collectFocusableElements(child);
+            });
+          }
+        }
+      }
+    };
+
+    // Start the traversal from the container
+    collectFocusableElements(this.container);
+
+    // Remove duplicates that might have been collected through different paths
+    // while preserving order
+    const uniqueElements = [];
+    const seen = new Set();
+
+    for (const element of orderedFocusableElements) {
+      if (!seen.has(element)) {
+        seen.add(element);
+        uniqueElements.push(element);
+      }
+    }
+
+    return uniqueElements;
   }
 
   focusFirstElement() {
@@ -121,16 +173,11 @@ export class FocusTrap {
   disconnect() {
     // Remove the tabIndex we set
     this.container.removeAttribute('tabIndex');
-    
+
     if (this.container.hasAttribute('data-focus-trap-container')) {
       this.container.removeAttribute('data-focus-trap-container');
     }
 
-    this.bookendStart.remove();
-    this.bookendEnd.remove();
     this.container.removeEventListener('keydown', this._onKeydown);
-    this.container.removeEventListener('focus', this._onContainerFocus);
-    this.bookendStart.removeEventListener('focus', this._onBookendFocusStart);
-    this.bookendEnd.removeEventListener('focus', this._onBookendFocusEnd);
   }
 }


### PR DESCRIPTION
fix: update focus trap logic to improve focus management by accounting for web components / shadow dom and slot structure


TO DO LATER:
- https://github.com/AlaskaAirlines/auro-library/issues/166
- filter out auro-components which is not actually focusable. ( such as disabled, hyperlink without href...)

# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [X] My update follows the CONTRIBUTING guidelines of this project
- [X] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Improve focus trapping to account for web components, shadow DOM, and slot structures by replacing bookend approach with recursive focusable element traversal and keydown-based wrapping.

Bug Fixes:
- Handle focusable elements inside shadow DOM and slotted content correctly

Enhancements:
- Replace bookend elements with keyboard event logic for focus wrapping
- Introduce recursive traversal to collect focusable elements from both light and shadow DOM
- Separate native selectors and custom component tags into dedicated focusable lists

Chores:
- Remove manual version export from drawerVersion file