### PR TITLE
feat: add `drawer-backdrop` csspart

### DIFF
--- a/apiExamples/customizing.html
+++ b/apiExamples/customizing.html
@@ -10,8 +10,11 @@
     transform: scale(2);
   }
   #customizedDrawer ::part(drawer-wrapper) {
-    background: linear-gradient(180deg, #cdcdcd 50%, slategrey 100%);
+    background: linear-gradient(180deg, var(  --ds-advanced-color-accents-accent1) 50%, var(--ds-advanced-color-accents-accent1-muted) 100%);
     width: 50%;
+  }
+  #customizedDrawer::part(drawer-backdrop) {
+    background: var(--ds-advanced-color-button-primary-background-inverse-disabled);
   }
 </style>
 <div>

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -159,6 +159,7 @@ Within the scope of the auro-drawer there is `aria-labelledby="drawer-header"`. 
 
 The drawer's size and some styles can be styled using CSS `part`.
 
+- `auro-drawer::part(backdrop)` to style the backdrop behind the the content wrapper.
 - `auro-drawer ::part(drawer-wrapper)` to style the container of the drawer content.
 - `auro-drawer ::part(drawer-header)` to style the header.
 - `auro-drawer ::part(drawer-content)` to style the content wrapper.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@aurodesignsystem/auro-drawer",
-  "version": "4.1.5",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aurodesignsystem/auro-drawer",
-      "version": "4.1.5",
+      "version": "4.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aurodesignsystem/auro-button": "11.1.0",
+        "@aurodesignsystem/auro-button": "11.2.1",
         "@aurodesignsystem/auro-icon": "8.0.4",
-        "@aurodesignsystem/auro-library": "^5.1.0",
+        "@aurodesignsystem/auro-library": "^5.2.2",
         "@aurodesignsystem/design-tokens": "^5.14.0",
         "@aurodesignsystem/webcorestylesheets": "6.2.0",
         "chalk": "^5.4.1",
@@ -335,9 +335,9 @@
       }
     },
     "node_modules/@aurodesignsystem/auro-button": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-button/-/auro-button-11.1.0.tgz",
-      "integrity": "sha512-NZFXKFNPS4mTakVULIqtFb2wtKk6JW7T57Sef47+rI4k2f/RH9JCJkUENT67v3MNQl3gz8Q8VdejO21Y/1REeg==",
+      "version": "11.2.1",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-button/-/auro-button-11.2.1.tgz",
+      "integrity": "sha512-CVUIcdjBgzp25ypDi5kwZCk8cMGXyhmf9MwKlSbQWMdBXfS2jdU8TP1LKcAOoIjQsvKTxh/gaUhEmEbnmoaJdA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -935,9 +935,9 @@
       }
     },
     "node_modules/@aurodesignsystem/auro-library": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.1.0.tgz",
-      "integrity": "sha512-oHcNnsiCd4rhoPJ7fP2Wrw2XTFy9acY4wMTsxolMTZzsdLavegGz8VCTIVNvh3snhXRq6ZuyZrX9+cEW70kI4A==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@aurodesignsystem/auro-library/-/auro-library-5.2.2.tgz",
+      "integrity": "sha512-qxw3C8VEnm7nmjFr6XgdK/yMM1g0EZ4Wa/6fPfEEy4VPZP96mJIvnT3l1wXuxsWM+lwu1k3TnW8qKPeeg98KXQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aurodesignsystem/auro-cli": "^2.5.0",

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "node": "^20.x || ^22.x "
   },
   "dependencies": {
-    "@aurodesignsystem/auro-button": "11.1.0",
+    "@aurodesignsystem/auro-button": "11.2.1",
     "@aurodesignsystem/auro-icon": "8.0.4",
-    "@aurodesignsystem/auro-library": "^5.1.0",
+    "@aurodesignsystem/auro-library": "^5.2.2",
     "@aurodesignsystem/design-tokens": "^5.14.0",
     "@aurodesignsystem/webcorestylesheets": "6.2.0",
     "chalk": "^5.4.1",

--- a/src/auro-drawer.js
+++ b/src/auro-drawer.js
@@ -25,7 +25,8 @@ const CONFIG = {
  * @slot close - Used to replace the close button.
  *
  * @fires auroDrawer-toggled - Event fired when the drawer is toggled open or closed.
- * 
+ *
+ * @csspart drawer-backdrop - to style the backdrop behind the the content wrapper.
  * @csspart drawer-wrapper - to style the content wrapper.
  * @csspart drawer-header - to style the header.
  * @csspart drawer-content - to style the container of the drawer content.
@@ -178,6 +179,8 @@ export class AuroDrawer extends AuroFloater {
     this.drawerBib = document.createElement('auro-drawer-content');
     this.drawerBib.addEventListener('close-click', () => this.floater.hideBib());
     this.append(this.drawerBib);
+
+    this.bib.setAttribute('exportparts', 'backdrop:drawer-backdrop');
 
     this.setupAria();
   }

--- a/src/auro-floater-bib.js
+++ b/src/auro-floater-bib.js
@@ -34,7 +34,7 @@ export class AuroFloaterBib extends LitElement {
   render() {
     return html`
       <div class="container">
-        <div class="backdrop"></div>
+        <div class="backdrop" part="backdrop"></div>
         <slot></slot>
       </div>
     `;

--- a/src/buttonVersion.js
+++ b/src/buttonVersion.js
@@ -1,1 +1,1 @@
-export default '11.1.0'
+export default '11.2.1'

--- a/src/drawerVersion.js
+++ b/src/drawerVersion.js
@@ -1,1 +1,1 @@
-export default '4.1.5'
+export default '4.2.0'


### PR DESCRIPTION
# Alaska Airlines Pull Request

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Expose a `backdrop` CSS part on AuroDrawer and AuroFloaterBib components to enable custom styling of their backdrop elements.

New Features:
- Add `part="backdrop"` attribute and `exportparts` declaration to AuroFloaterBib for backdrop styling.
- Introduce `@csspart backdrop` in AuroDrawer to allow backdrop customization via CSS part.

Documentation:
- Document the new `auro-drawer::part(backdrop)` selector in API documentation.
- Update customizing example to demonstrate styling the backdrop with `::part(backdrop)`.