### PR TITLE
fix: not to take away focus before drawer opens completely

### DIFF
--- a/src/auro-drawer-content.js
+++ b/src/auro-drawer-content.js
@@ -84,7 +84,6 @@ export class AuroDrawerContent extends LitElement {
         if (this.prevActiveElement === document.body && this.triggerElement) {
           this.prevActiveElement = this.triggerElement;
         }
-        this.prevActiveElement.blur();
       } else {
         if (this.prevActiveElement) {
           this.prevActiveElement.focus();

--- a/src/drawerVersion.js
+++ b/src/drawerVersion.js
@@ -1,1 +1,1 @@
-export default '4.3.0'
+export default '4.3.1'

--- a/src/styles/floaterBibColor.scss
+++ b/src/styles/floaterBibColor.scss
@@ -1,7 +1,5 @@
-:host([onbackdrop]) {
-  .backdrop {
-    background: var(--ds-auro-floater-backdrop-modal-background-color);
-  }
+:host([onbackdrop]) .backdrop { // stylelint-disable scss/selector-nest-combinators
+  background: var(--ds-auro-floater-backdrop-modal-background-color);
 }
 
 ::slotted(*) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

closes #81 

This is to fix the nested drawer got hide immediately after open when using the trigger button.

As the trigger losses focus, drawer got to hide.
Since FocusTrap is in action, no need to forcefully take away the focus from the trigger. 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Maintain trigger element focus until the drawer opens, refine backdrop styling selector, and update version export.

Bug Fixes:
- Prevent the trigger element from losing focus before the drawer finishes opening to avoid nested drawer flicker

Enhancements:
- Simplify the SCSS selector for the drawer backdrop under onbackdrop state

Build:
- Remove the hardcoded drawerVersion export