### PR TITLE
fix: close button not to overlap with headline area

### DIFF
--- a/src/auro-drawer-content.js
+++ b/src/auro-drawer-content.js
@@ -106,30 +106,30 @@ export class AuroDrawerContent extends LitElement {
     return html`
     <div class="wrapper" tabindex="-1" part="drawer-wrapper" @transitionend=${this.handleWrapperTransitionEnd}>
       ${this.unformatted ? '' : html`
-        <div part="drawer-header" class="header">
-            <h1 class="heading heading-lg util_stackMarginNone--top" id="drawer-header">
+        <div class="header-row">
+            <h1 class="heading heading-lg util_stackMarginNone--top" id="drawer-header" part="drawer-header">
               <slot name="header"></slot>
             </h1>
+          ${this.modal ? '' :
+            html`
+            <div id="closeButton" @click="${this.handleCloseButtonClick}">
+              <slot name="close">
+                <${this.buttonTag} 
+                part="close-button"
+                variant="ghost"
+                shape="circle"
+                size="sm"
+                ?onDark=${this.onDark} 
+                aria-label="Close">
+                  <${this.iconTag} ?customColor="${this.onDark}" category="interface" name="x-lg"></${this.iconTag}>
+                  <span class="util_displayHiddenVisually">Close</span>
+                </${this.buttonTag}>
+              </slot>
+            </div>
+            `
+          }
         </div>
       `}
-      ${this.modal ? '' :
-        html`
-        <div id="closeButton" @click="${this.handleCloseButtonClick}">
-          <slot name="close">
-            <${this.buttonTag} 
-            part="close-button"
-            variant="ghost"
-            shape="circle"
-            size="sm"
-            ?onDark=${this.onDark} 
-            aria-label="Close">
-              <${this.iconTag} ?customColor="${this.onDark}" category="interface" name="x-lg"></${this.iconTag}>
-              <span class="util_displayHiddenVisually">Close</span>
-            </${this.buttonTag}>
-          </slot>
-        </div>
-        `
-      }
       <div part="drawer-content" class="content body-default">
         <slot></slot>
         <slot name="content"></slot>

--- a/src/drawerVersion.js
+++ b/src/drawerVersion.js
@@ -1,1 +1,1 @@
-export default '4.3.1'
+export default '4.3.2'

--- a/src/styles/drawerContentStyles.scss
+++ b/src/styles/drawerContentStyles.scss
@@ -25,10 +25,11 @@
     will-change: transform;
   }
 
-  .header {
+  .header-row {
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
+    gap: var(--ds-size-200, #{vac.$ds-size-200});
   }
 
   .footer {
@@ -36,6 +37,10 @@
     align-items: flex-start;
     justify-content: flex-end;
     margin-top: var(--insetPaddingXl);
+  }
+
+  .heading {
+    margin-block-start: 0;
   }
 }
 
@@ -48,16 +53,7 @@
 }
 
 #closeButton {
-  position: absolute;
-  top: var(--insetPaddingXl);
-  right: var(--insetPaddingXl);
-  padding: 0;
-  margin: 0;
-
-  @include breakpoints.auro_grid-breakpoint--lg {
-    top: var(--insetPaddingXxxl);
-    right: var(--insetPaddingXxxl);
-  }
+  margin-left: auto;
 
   &:hover {
     cursor: pointer;


### PR DESCRIPTION
# Alaska Airlines Pull Request

closes https://github.com/AlaskaAirlines/auro-formkit/issues/975

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Move the close button into the drawer header and adjust styles to leverage flex layout and prevent overlap with the headline area.

Bug Fixes:
- Fix overlap of close button with the header area

Enhancements:
- Replace header container with a new header-row flex container and add gap between heading and close button
- Remove absolute positioning of close button and align it with margin-left auto in the header row
- Reset heading top margin for consistent spacing