### PR TITLE
fix: hide bib on disconnect to restore page scroll

### DIFF
--- a/src/auro-floater.js
+++ b/src/auro-floater.js
@@ -83,7 +83,10 @@ export class AuroFloater extends LitElement {
   }
 
   disconnectedCallback() {
-    this.floater.disconnect();
+    if (this.floater) {
+      this.floater.hideBib('disconnect');
+      this.floater.disconnect();
+    }
   }
 
   updated(changedProperties) {


### PR DESCRIPTION
# Alaska Airlines Pull Request

call floater.hideBIb when drawer gets disconnected from document so that styles related to scroll can reset 

How to test
1. on doc, open a drawer
2. on inspecter, find the drawer element 
3. right click, select Delete element menu
4. try scroll up and down
5. you should be able to scroll the page 

## Review Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

<details>
<summary>
RC Checklist
</summary>

## Testing Checklist:

### Browsers

[Browsers Support Guide](https://auro.alaskaair.com/support/browsersSupport)

[Dev demo link](https://alaskaairlines.github.io/auro-drawer/)

Android

- [ ] Chrome
- [ ] Firefox

 iOS

- [ ] Chrome
- [ ] Firefox
- [ ] Safari

Desktop

- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge

### Scenarios

- [ ] Validated linked issues with issue reporting team
- [ ] Test coverage report review

[Framework playground ](https://github.com/AlaskaAirlines/auro-framework-playground)

- [ ] Next React
- [ ] SvelteKit

</details><br>
**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team

## Summary by Sourcery

Bug Fixes:
- Reset scroll-related styles by calling floater.hideBib when the drawer floater is disconnected from the document.